### PR TITLE
Config option for bot's default timezone

### DIFF
--- a/matrix_reminder_bot/chat_functions.py
+++ b/matrix_reminder_bot/chat_functions.py
@@ -1,7 +1,8 @@
 import logging
 
-from markdown import markdown
 from nio import SendRetryError
+
+from markdown import markdown
 
 logger = logging.getLogger(__name__)
 

--- a/matrix_reminder_bot/config.py
+++ b/matrix_reminder_bot/config.py
@@ -4,8 +4,9 @@ import re
 import sys
 from typing import Any, List
 
-import yaml
+import pytz
 
+import yaml
 from matrix_reminder_bot.errors import ConfigError
 
 logger = logging.getLogger()
@@ -85,6 +86,10 @@ class Config(object):
 
         self.command_prefix = self._get_cfg(["command_prefix"], default="!c")
 
+        # Reminder configuration
+        timezone_str = self._get_cfg(["reminders", "timezone"], default="Etc/UTC")
+        self.timezone = pytz.timezone(timezone_str)
+
     def _get_cfg(
             self,
             path: List[str],
@@ -106,7 +111,7 @@ class Config(object):
             # If at any point we don't get our expected option...
             if config is None:
                 # Raise an error if it was required
-                if required or not default:
+                if required and not default:
                     raise ConfigError(f"Config option {'.'.join(path)} is required")
 
                 # or return the default value

--- a/matrix_reminder_bot/main.py
+++ b/matrix_reminder_bot/main.py
@@ -30,7 +30,8 @@ async def main():
     # Configure the database
     store = Storage(config.database)
 
-    # Start the python job scheduler
+    # Configure and start the python job scheduler
+    SCHEDULER.configure({"apscheduler.timezone": config.timezone})
     SCHEDULER.start()
 
     # Configuration options for the AsyncClient

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -13,7 +13,7 @@ matrix:
   user_password: ""
   # The public URL at which the homeserver's Client-Server API can be accessed
   homeserver_url: https://example.com
-  # The device ID that is **non pre-existing** device
+  # The device ID that is a **non pre-existing** device
   # If this device ID already exists, messages will be dropped silently in
   # encrypted rooms
   device_id: REMINDER
@@ -33,7 +33,7 @@ storage:
   store_path: "./store"
 
 reminders:
-  # Uncomment to set a default timezone that will be used when creating reminders
+  # Uncomment to set a default timezone that will be used when creating reminders.
   # If not set, UTC will be used
   #timezone: "Europe/London"
 

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -32,6 +32,11 @@ storage:
   # containing encryption keys, sync tokens, etc.
   store_path: "./store"
 
+reminders:
+  # Uncomment to set a default timezone that will be used when creating reminders
+  # If not set, UTC will be used
+  #timezone: "Europe/London"
+
 # Logging setup
 logging:
   # Logging level

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "dateparser>=0.7.4",
         "readabledelta>=0.0.2",
         "apscheduler>=3.6.3",
+        "pytz>=2020.1",
     ],
     extras_require={
         "postgres": ["psycopg2>=2.8.5"],


### PR DESCRIPTION
Fixes #5 

Creates a config option to set the default timezone configuration for all reminders.

After this will be adding a way to set a timezone on a per-room basis.