### PR TITLE
Timezone fixes

### DIFF
--- a/matrix_reminder_bot/chat_functions.py
+++ b/matrix_reminder_bot/chat_functions.py
@@ -1,8 +1,7 @@
 import logging
 
-from nio import SendRetryError
-
 from markdown import markdown
+from nio import SendRetryError
 
 logger = logging.getLogger(__name__)
 

--- a/matrix_reminder_bot/config.py
+++ b/matrix_reminder_bot/config.py
@@ -4,8 +4,9 @@ import re
 import sys
 from typing import Any, List
 
-import yaml
 import pytz
+import yaml
+
 from matrix_reminder_bot.errors import ConfigError
 
 logger = logging.getLogger()
@@ -86,8 +87,7 @@ class Config(object):
         self.command_prefix = self._get_cfg(["command_prefix"], default="!c")
 
         # Reminder configuration
-        self.timezone_str = self._get_cfg(["reminders", "timezone"], default="Etc/UTC")
-        self.timezone = pytz.timezone(self.timezone_str)
+        self.timezone = self._get_cfg(["reminders", "timezone"], default="Etc/UTC")
 
     def _get_cfg(
             self,

--- a/matrix_reminder_bot/config.py
+++ b/matrix_reminder_bot/config.py
@@ -4,9 +4,8 @@ import re
 import sys
 from typing import Any, List
 
-import pytz
-
 import yaml
+import pytz
 from matrix_reminder_bot.errors import ConfigError
 
 logger = logging.getLogger()
@@ -87,8 +86,8 @@ class Config(object):
         self.command_prefix = self._get_cfg(["command_prefix"], default="!c")
 
         # Reminder configuration
-        timezone_str = self._get_cfg(["reminders", "timezone"], default="Etc/UTC")
-        self.timezone = pytz.timezone(timezone_str)
+        self.timezone_str = self._get_cfg(["reminders", "timezone"], default="Etc/UTC")
+        self.timezone = pytz.timezone(self.timezone_str)
 
     def _get_cfg(
             self,

--- a/matrix_reminder_bot/main.py
+++ b/matrix_reminder_bot/main.py
@@ -28,7 +28,7 @@ async def main():
     config = Config(config_filepath)
 
     # Configure the database
-    store = Storage(config.database)
+    store = Storage(config)
 
     # Configure the python job scheduler
     SCHEDULER.configure({"apscheduler.timezone": config.timezone})


### PR DESCRIPTION
We now store timezone database strings in the database instead of UTC offsets encoded as part of datetime strings. This should be more robust and last across DST boundaries. In addition, database migrations should be more robust.

During the database migration to add the new `timezone` column, the default timezone in your config file will be applied to all reminders.

**If you have any timezones that have a UTC offset attached, the bot will crash on startup. You need to manually fix them by removing the `+xx:xx` or `-xx:xx` at the end of the time string.**

cc @HarHarLinks @djmaze