### PR TITLE
Prevent a case where timezone-aware datetimes were being passed to Reminder

### DIFF
--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -123,15 +123,17 @@ class Command(object):
             logger.debug("Start time: %s", time_str)
 
         # Convert start time string to a datetime object
-        time = self._parse_str_to_time(time_str)
+        time = self._parse_str_to_time(time_str, tz_aware=False)
 
         return time, reminder_text, recurse_timedelta
 
-    def _parse_str_to_time(self, time_str: str) -> datetime:
+    def _parse_str_to_time(self, time_str: str, tz_aware: bool = True) -> datetime:
         """Converts a human-readable, future time string to a datetime object
 
         Args:
             time_str: The time to convert
+            tz_aware: Whether the returned datetime should have associated timezone
+                information
 
         Returns:
             datetime: A datetime if conversion was successful
@@ -144,14 +146,15 @@ class Command(object):
             settings={
                 "PREFER_DATES_FROM": "future",
                 "TIMEZONE": CONFIG.timezone,
-                "RETURN_AS_TIMEZONE_AWARE": True,
+                "RETURN_AS_TIMEZONE_AWARE": tz_aware,
             },
         )
         if not time:
             raise CommandError(f"The given time '{time_str}' is invalid.")
 
         # Disallow times in the past
-        if time < self._get_datetime_now(CONFIG.timezone):
+        tzinfo = pytz.timezone(CONFIG.timezone)
+        if time.replace(tzinfo=tzinfo) < self._get_datetime_now(CONFIG.timezone):
             raise CommandError(f"The given time '{time_str}' is in the past.")
 
         # Round datetime object to the nearest second for nicer display


### PR DESCRIPTION
Helps address #63.

We were passing a timezone-aware instance of `start_time` to Reminder, which some new code introduced in https://github.com/anoadragon453/matrix-reminder-bot/commit/5d5457f570bb46f5c6c97c979c8c312f80656985 didn't expect. The end result is that recurring reminders could no longer be created.

Thanks for @dzordzu for the discovery and helping out!