### PR TITLE
Update setup.py to indicate Python 3.6 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
See: https://github.com/anoadragon453/matrix-reminder-bot/blob/c8e03a0a4fbaf805814f246d8d1b0429793aa5c2/matrix_reminder_bot/__init__.py#L4 and ab1a3a7039a2103f24fdefcba66c044c6e963d9e

Probably 3.9 could also be added as a supported version?