### PR TITLE
replace pretty_cron with cron_descriptor

### DIFF
--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -11,7 +11,7 @@ from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from nio import AsyncClient, MatrixRoom
 from nio.events.room_events import RoomMessageText
-from cron_descriptor import get_description
+from cron_descriptor import get_description, Options
 from readabledelta import readabledelta
 
 from matrix_reminder_bot.config import CONFIG
@@ -462,7 +462,9 @@ class Command(object):
             # Cron-based reminders
             if isinstance(reminder.job.trigger, CronTrigger):
                 # A human-readable cron tab, in addition to the actual tab
-                line += f"{get_description(reminder.cron_tab)} (`{reminder.cron_tab}`); next run {next_execution.humanize()}"
+                o = Options()
+                o.use_24hour_time_format = True
+                line += f"{get_description(reminder.cron_tab, options=o)} (`{reminder.cron_tab}`); next run {next_execution.humanize()}"
 
             # One-time reminders
             elif isinstance(reminder.job.trigger, DateTrigger):

--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -11,7 +11,7 @@ from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from nio import AsyncClient, MatrixRoom
 from nio.events.room_events import RoomMessageText
-from pretty_cron import prettify_cron
+from cron_descriptor import get_description
 from readabledelta import readabledelta
 
 from matrix_reminder_bot.config import CONFIG
@@ -462,7 +462,7 @@ class Command(object):
             # Cron-based reminders
             if isinstance(reminder.job.trigger, CronTrigger):
                 # A human-readable cron tab, in addition to the actual tab
-                line += f"{prettify_cron(reminder.cron_tab)} (`{reminder.cron_tab}`); next run {next_execution.humanize()}"
+                line += f"{get_description(reminder.cron_tab)} (`{reminder.cron_tab}`); next run {next_execution.humanize()}"
 
             # One-time reminders
             elif isinstance(reminder.job.trigger, DateTrigger):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "apscheduler>=3.6.3",
         "pytz>=2020.1",
         "arrow>=0.17.0",
-        "pretty_cron>=1.2.0",
+        "cron_descriptor>=1.2.24",
     ],
     extras_require={
         "postgres": ["psycopg2>=2.8.5"],


### PR DESCRIPTION
Probably resolves #73 - assuming this library never has to fall back to cron syntax as the old one did.
My example there was `0 11,20 * * *` which the new lib words as "'At 11:00 and 20:00". I chose the 24hour format specifically to match the crontab better, but feel free to ignore that commit.

On a side note, this lib supports a couple localized output formats, if the bot is ever going to support that.

Perhaps it should still check for and escape `*` which are not in code blocks.