### PR TITLE
Bump versions & add CI

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+
+env:
+  DOCKER_IMAGE: ghcr.io/anoadragon453/matrix-reminder-bot
+
+jobs:
+  docker-build-python-versions-matrix:
+    strategy:
+      matrix:
+        version: ['3.9', '3.10', '3.11', '3.12']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # required for changesets
+          fetch-depth: '0'
+          # don't persist the credentials so the changesets action doesn't use the
+          # github actions token but the git token provided via environment variable
+          persist-credentials: false
+
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Docker build
+        uses: docker/build-push-action@v5
+        id: dockerBuild
+        with:
+          push: false
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-arg: PYTHON_VERSION=${{ matrix.version }}
+
+  docker-build-push-ghcr:
+    runs-on: ubuntu-latest
+    outputs:
+      docker-tag: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # required for changesets
+          fetch-depth: '0'
+          # don't persist the credentials so the changesets action doesn't use the
+          # github actions token but the git token provided via environment variable
+          persist-credentials: false
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          labels: |
+            org.opencontainers.image.title=Matrix Reminder Bot
+            org.opencontainers.image.description=A bot to remind you about stuff. Supports encrypted rooms.
+          tags: |
+            type=ref,enable=true,priority=900,event=tag
+            type=raw,value=latest,enable={{tag != ''}},priority=800
+            type=raw,value=dev,enable={{is_default_branch}},priority=700
+            type=ref,event=pr,enable=true,priority=600
+
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Docker build and push
+        uses: docker/build-push-action@v5
+        id: dockerBuild
+        with:
+          push: true
+          context: .
+          file: ./docker/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies
       run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,12 +6,12 @@
 # There is an optional PYTHON_VERSION build argument which sets the
 # version of python to build against. For example:
 #
-#    docker build -f docker/Dockerfile --build-arg PYTHON_VERSION=3.8 .
+#    docker build -f docker/Dockerfile --build-arg PYTHON_VERSION=3.9 .
 #
 # An optional LIBOLM_VERSION build argument which sets the
 # version of libolm to build against. For example:
 #
-#    docker build -f docker/Dockerfile --build-arg LIBOLM_VERSION=3.2.4 .
+#    docker build -f docker/Dockerfile --build-arg LIBOLM_VERSION=3.2.15 .
 #
 
 
@@ -22,15 +22,15 @@
 # We use an initial docker container to build all of the runtime dependencies,
 # then transfer those dependencies to the container we're going to ship,
 # before throwing this one away
-ARG PYTHON_VERSION=3.9
-FROM docker.io/python:${PYTHON_VERSION}-alpine3.12 as builder
+ARG PYTHON_VERSION=3.11
+FROM docker.io/python:${PYTHON_VERSION}-alpine3.18 as builder
 
 ##
 ## Build libolm for matrix-nio e2e support
 ##
 
 # Install libolm build dependencies
-ARG LIBOLM_VERSION=3.2.4
+ARG LIBOLM_VERSION=3.2.15
 RUN apk add --no-cache \
     make \
     cmake \
@@ -79,7 +79,7 @@ RUN pip install --prefix="/python-libs" --no-warn-script-location "/src/.[postgr
 
 # Create the container we'll actually ship. We need to copy libolm and any
 # python dependencies that we built above to this container
-FROM docker.io/python:${PYTHON_VERSION}-alpine3.12
+FROM docker.io/python:${PYTHON_VERSION}-alpine3.18
 
 # Copy python dependencies from the "builder" container
 COPY --from=builder /python-libs /usr/local

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -13,23 +13,23 @@
 # There is an optional PYTHON_VERSION build argument which sets the
 # version of python to build against. For example:
 #
-#    docker build -f docker/Dockerfile --build-arg PYTHON_VERSION=3.8 .
+#    docker build -f docker/Dockerfile --build-arg PYTHON_VERSION=3.9 .
 #
 # An optional LIBOLM_VERSION build argument which sets the
 # version of libolm to build against. For example:
 #
-#    docker build -f docker/Dockerfile --build-arg LIBOLM_VERSION=3.1.4 .
+#    docker build -f docker/Dockerfile --build-arg LIBOLM_VERSION=3.2.15 .
 #
 
-ARG PYTHON_VERSION=3.9
-FROM docker.io/python:${PYTHON_VERSION}-alpine3.12
+ARG PYTHON_VERSION=3.11
+FROM docker.io/python:${PYTHON_VERSION}-alpine3.18
 
 ##
 ## Build libolm for matrix-nio e2e support
 ##
 
 # Install libolm build dependencies
-ARG LIBOLM_VERSION=3.2.1
+ARG LIBOLM_VERSION=3.2.15
 RUN apk add --no-cache \
     make \
     cmake \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       dockerfile: docker/Dockerfile
       # Build arguments may be specified here
       # args:
-      #  PYTHON_VERSION: 3.8
+      #  PYTHON_VERSION: 3.11
     volumes:
       - data_volume:/data
     # Used for allowing connections to homeservers hosted on the host machine
@@ -44,7 +44,7 @@ services:
       dockerfile: docker/Dockerfile.dev
       # Build arguments may be specified here
       # args:
-      #  PYTHON_VERSION: 3.8
+      #  PYTHON_VERSION: 3.11
     volumes:
       - data_volume:/data
     # Used for allowing connections to homeservers hosted on the host machine

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,9 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- bump python version to 3.11
- bump libolm to 3.2.15
- on release, PR, and push to master
- for all supported Python versions
- publish the container with the current default Python version to GHCR.io