### PR TITLE
Implement allowlist and blocklist

### DIFF
--- a/matrix_reminder_bot/callbacks.py
+++ b/matrix_reminder_bot/callbacks.py
@@ -132,7 +132,7 @@ class Callbacks(object):
 
         # Don't respond to invites from disallowed users
         if not is_allowed_user(event.sender):
-            logger.info(f"{event.sender} is not allowed, not responding to invite.")
+            logger.debug(f"{event.sender} is not allowed, not responding to invite.")
             return
 
         # Attempt to join 3 times before giving up

--- a/matrix_reminder_bot/config.py
+++ b/matrix_reminder_bot/config.py
@@ -42,6 +42,12 @@ class Config:
 
         self.timezone: str = ""
 
+        self.allowlist_enabled: bool = False
+        self.allowlist_regexes: list[str] = []
+
+        self.blocklist_enabled: bool = False
+        self.blocklist_regexes: list[str] = []
+
     def read_config(self, filepath: str):
         if not os.path.isfile(filepath):
             raise ConfigError(f"Config file '{filepath}' does not exist")
@@ -121,6 +127,48 @@ class Config:
 
         # Reminder configuration
         self.timezone = self._get_cfg(["reminders", "timezone"], default="Etc/UTC")
+
+        # Allowlist configuration
+        allowlist_enabled = self._get_cfg(["allowlist", "enabled"], required=True)
+        if not isinstance(allowlist_enabled, bool):
+            raise ConfigError("allowlist.enabled must be a boolean value")
+        self.allowlist_enabled = allowlist_enabled
+
+        allowlist_regexes = self._get_cfg(["allowlist", "regexes"], required=True)
+        if not isinstance(allowlist_regexes, list) or (
+            isinstance(allowlist_regexes, list)
+            and any(not isinstance(x, str) for x in allowlist_regexes)
+        ):
+            raise ConfigError("allowlist.regexes must be a list of strings")
+        for regex in allowlist_regexes:
+            try:
+                re.compile(regex)
+            except re.error:
+                raise ConfigError(
+                    f"'{regex}' contained in allowlist.regexes is not a valid regular expression"
+                )
+        self.allowlist_regexes = allowlist_regexes
+
+        # Blocklist configuration
+        blocklist_enabled = self._get_cfg(["blocklist", "enabled"], required=True)
+        if not isinstance(blocklist_enabled, bool):
+            raise ConfigError("blocklist.enabled must be a boolean value")
+        self.blocklist_enabled = blocklist_enabled
+
+        blocklist_regexes = self._get_cfg(["blocklist", "regexes"], required=True)
+        if not isinstance(blocklist_regexes, list) or (
+            isinstance(blocklist_regexes, list)
+            and any(not isinstance(x, str) for x in blocklist_regexes)
+        ):
+            raise ConfigError("blocklist.regexes must be a list of strings")
+        for regex in blocklist_regexes:
+            try:
+                re.compile(regex)
+            except re.error:
+                raise ConfigError(
+                    f"'{regex}' contained in blocklist.regexes is not a valid regular expression"
+                )
+        self.blocklist_regexes = blocklist_regexes
 
     def _get_cfg(
         self,

--- a/matrix_reminder_bot/config.py
+++ b/matrix_reminder_bot/config.py
@@ -43,10 +43,10 @@ class Config:
         self.timezone: str = ""
 
         self.allowlist_enabled: bool = False
-        self.allowlist_regexes: list[str] = []
+        self.allowlist_regexes: list[re.Pattern] = []
 
         self.blocklist_enabled: bool = False
-        self.blocklist_regexes: list[str] = []
+        self.blocklist_regexes: list[re.Pattern] = []
 
     def read_config(self, filepath: str):
         if not os.path.isfile(filepath):
@@ -134,15 +134,17 @@ class Config:
             raise ConfigError("allowlist.enabled must be a boolean value")
         self.allowlist_enabled = allowlist_enabled
 
-        allowlist_regexes = self._get_cfg(["allowlist", "regexes"], required=True)
-        if not isinstance(allowlist_regexes, list) or (
-            isinstance(allowlist_regexes, list)
-            and any(not isinstance(x, str) for x in allowlist_regexes)
+        allowlist_strings = self._get_cfg(["allowlist", "regexes"], required=True)
+        if not isinstance(allowlist_strings, list) or (
+            isinstance(allowlist_strings, list)
+            and any(not isinstance(x, str) for x in allowlist_strings)
         ):
             raise ConfigError("allowlist.regexes must be a list of strings")
-        for regex in allowlist_regexes:
+
+        allowlist_regexes = []
+        for regex in allowlist_strings:
             try:
-                re.compile(regex)
+                allowlist_regexes.append(re.compile(regex))
             except re.error:
                 raise ConfigError(
                     f"'{regex}' contained in allowlist.regexes is not a valid regular expression"
@@ -155,15 +157,17 @@ class Config:
             raise ConfigError("blocklist.enabled must be a boolean value")
         self.blocklist_enabled = blocklist_enabled
 
-        blocklist_regexes = self._get_cfg(["blocklist", "regexes"], required=True)
-        if not isinstance(blocklist_regexes, list) or (
-            isinstance(blocklist_regexes, list)
-            and any(not isinstance(x, str) for x in blocklist_regexes)
+        blocklist_strings = self._get_cfg(["blocklist", "regexes"], required=True)
+        if not isinstance(blocklist_strings, list) or (
+            isinstance(blocklist_strings, list)
+            and any(not isinstance(x, str) for x in blocklist_strings)
         ):
             raise ConfigError("blocklist.regexes must be a list of strings")
-        for regex in blocklist_regexes:
+
+        blocklist_regexes = []
+        for regex in blocklist_strings:
             try:
-                re.compile(regex)
+                blocklist_regexes.append(re.compile(regex))
             except re.error:
                 raise ConfigError(
                     f"'{regex}' contained in blocklist.regexes is not a valid regular expression"

--- a/matrix_reminder_bot/functions.py
+++ b/matrix_reminder_bot/functions.py
@@ -115,3 +115,29 @@ def make_pill(user_id: str, displayname: str = None) -> str:
         displayname = user_id
 
     return f'<a href="https://matrix.to/#/{user_id}">{displayname}</a>'
+
+
+def is_allowed_user(user_id: str) -> bool:
+    """Returns if the bot is allowed to interact with the given user
+
+    Args:
+        user_id: The MXID of the user.
+
+    Returns:
+        True, if the bot is allowed to interact with the given user.
+    """
+    allowed = not CONFIG.allowlist_enabled
+
+    if CONFIG.allowlist_enabled:
+        for regex in CONFIG.allowlist_regexes:
+            if regex.fullmatch(user_id):
+                allowed = True
+                break
+
+    if CONFIG.blocklist_enabled:
+        for regex in CONFIG.blocklist_regexes:
+            if regex.fullmatch(user_id):
+                allowed = False
+                break
+
+    return allowed

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -36,6 +36,33 @@ reminders:
   # If not set, UTC will be used
   #timezone: "Europe/London"
 
+# Restrict the bot to only respond to certain MXIDs
+allowlist:
+  # Set to true to enable the allowlist
+  enabled: false
+  # A list of MXID regexes to be allowed
+  # To allow a certain homeserver:
+  #     regexes: ["@[a-z0-9-_.]+:myhomeserver.tld"]
+  # To allow a set of users:
+  #     regexes: ["@alice:someserver.tld", "@bob:anotherserver.tld"]
+  # To allow nobody (same as blocking every MXID):
+  #     regexes: []
+  regexes: []
+
+# Prevent the bot from responding to certain MXIDs
+# If both allowlist and blocklist are enabled, blocklist entries takes precedence
+blocklist:
+  # Set to true to enable the blocklist
+  enabled: false
+  # A list of MXID regexes to be blocked
+  # To block a certain homeserver:
+  #     regexes: [".*:myhomeserver.tld"]
+  # To block a set of users:
+  #     regexes: ["@alice:someserver.tld", "@bob:anotherserver.tld"]
+  # To block absolutely everyone (same as allowing nobody):
+  #     regexes: [".*"]
+  regexes: []
+
 # Logging setup
 logging:
   # Logging level


### PR DESCRIPTION
This PR implements both allowlisting and blocklisting regexes of MXIDs.

**I have not completely tested these changes yet, this is still a draft version** to allow the maintainers to do an initial review and request changes before I do final testing.

@HarHarLinks What do you think? I'm still thinking about whether or not the bot should respond with an error message when receiving a message from a disallowed user. Especially with open issues of the bot spamming duplicate responses to old messages, I personally think we should just drop the events without any response. But this may be bad UX for accidentally disallowed users.