### PR TITLE
Push CI container images to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: ghcr
+name: docker
 
 on:
   push:
@@ -13,7 +13,7 @@ env:
   HUB_IMAGE: anoa/matrix-reminder-bot
 
 jobs:
-  docker-build-python-versions-matrix:
+  build-python-versions-matrix:
     strategy:
       matrix:
         version: ['3.8', '3.9', '3.10', '3.11']
@@ -41,7 +41,7 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.version }}
 
-  docker-build-push-ghcr:
+  build-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -9,7 +9,8 @@ on:
   pull_request:
 
 env:
-  DOCKER_IMAGE: ghcr.io/anoadragon453/matrix-reminder-bot
+  GHCR_IMAGE: ghcr.io/anoadragon453/matrix-reminder-bot
+  HUB_IMAGE: anoa/matrix-reminder-bot
 
 jobs:
   docker-build-python-versions-matrix:
@@ -54,7 +55,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKER_IMAGE }}
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.HUB_IMAGE }}
           labels: |
             org.opencontainers.image.title=Matrix Reminder Bot
             org.opencontainers.image.description=A bot to remind you about stuff. Supports encrypted rooms.
@@ -74,6 +77,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker build and push
         uses: docker/build-push-action@v5

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,12 @@ The docker image will run matrix-reminder-bot with a SQLite database and
 end-to-end encryption dependencies included. For larger deployments, a
 connection to a Postgres database backend is recommended.
 
+A pre-built image for amd64 and arm64 platforms is provided by our CI on both
+- https://hub.docker.com/r/anoa/matrix-reminder-bot
+- https://github.com/anoadragon453/matrix-reminder-bot/pkgs/container/matrix-reminder-bot.
+
+You can always also build the image yourself, see below for instructions.
+
 ## Setup
 
 ### The `/data` volume
@@ -88,6 +94,12 @@ docker-compose up -d matrix-reminder-bot
 
 This will use the `matrix-reminder-bot:latest` tag from
 [Docker Hub](https://hub.docker.com/r/anoa/matrix-reminder-bot).
+
+If you would rather pull the image from GHCR instead, you can use:
+
+```
+docker-compose up -d matrix-reminder-bot-ghcr
+```
 
 If you would rather run from the checked out code, you can use:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -87,7 +87,7 @@ docker-compose up -d matrix-reminder-bot
 (Logs can later be accessed with the `docker logs` command).
 
 This will use the `matrix-reminder-bot:latest` tag from
-[Docker Hub](https://hub.docker.com/anoa/matrix-reminder-bot).
+[Docker Hub](https://hub.docker.com/r/anoa/matrix-reminder-bot).
 
 If you would rather run from the checked out code, you can use:
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,19 @@ services:
     extra_hosts:
       - "localhost:${HOST_IP_ADDRESS}"
 
+  # Runs from the latest release, but pulls the image from GitHub instead of Docker Hub
+  matrix-reminder-bot-ghcr:
+    image: ghcr.io/anoadragon453/matrix-reminder-bot
+    restart: always
+    volumes:
+      - data_volume:/data
+    # Used for allowing connections to homeservers hosted on the host machine
+    # (while docker host mode is still broken on Linux).
+    #
+    # Defaults to 127.0.0.1 and is set in docker/.env
+    extra_hosts:
+      - "localhost:${HOST_IP_ADDRESS}"
+
   # Builds and runs an optimized container from local code
   local-checkout:
     build:


### PR DESCRIPTION
- push any built docker images to both ghcr and docker hub
- update docs

**! need to set `secrets.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_TOKEN` in the repo settings !**