### PR TITLE
require setting a non-empty password in the config

### DIFF
--- a/matrix_reminder_bot/config.py
+++ b/matrix_reminder_bot/config.py
@@ -116,7 +116,10 @@ class Config:
             raise ConfigError("matrix.user_id must be in the form @name:domain")
         self.user_id = user_id
 
-        self.user_password = self._get_cfg(["matrix", "user_password"], required=True)
+        user_password = self._get_cfg(["matrix", "user_password"], required=True)
+        if len(user_password) <= 0:
+            raise ConfigError("please supply a password to log in!")
+        self.user_password = user_password
         self.device_id = self._get_cfg(["matrix", "device_id"], required=True)
         self.device_name = self._get_cfg(
             ["matrix", "device_name"], default="nio-template"

--- a/matrix_reminder_bot/main.py
+++ b/matrix_reminder_bot/main.py
@@ -65,7 +65,7 @@ async def main():
     # Keep trying to reconnect on failure (with some time in-between)
     while True:
         try:
-            # Try to login with the configured username/password
+            # Try to log in with the configured username/password
             try:
                 login_response = await client.login(
                     password=CONFIG.user_password,


### PR DESCRIPTION
before this, when not updating the sample config's empty password before starting the bot, it would fail to log in.

now, the config class validates the password isn't empty.