### PR TITLE
fix _get_datetime_now to use UTC offset for current (non-)DST

### DIFF
--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 def _get_datetime_now(tz: str) -> datetime:
     """Returns a timezone-aware datetime object of the current time"""
     # Get a datetime with no timezone information
-    no_timezone_datetime = datetime(2009, 9, 1)
+    no_timezone_datetime = datetime.now()
 
     # Create a datetime.timezone object with the correct offset from UTC
     offset = timezone(pytz.timezone(tz).utcoffset(no_timezone_datetime))


### PR DESCRIPTION
Hardcoding the `no_timezone_datetime` to September meant that the `utcoffset` calculated by pytz was always based on the DST variant. Using a naive `now` makes it automatically choose the correct DST, possibly except for an edge case on DST borders where it might fail.