### PR TITLE
Bump dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "readabledelta>=0.0.2",
         "apscheduler>=3.10.4",
         "pytz>=2024.1",
-        "arrow>=0.17.0",
+        "arrow>=1.3.0",
         "pretty_cron>=1.2.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         "matrix-nio[e2e]>=0.24.0",
         "Markdown>=3.5.2",
-        "PyYAML>=5.1.2",
+        "PyYAML>=6.0.1",
         "dateparser>=0.7.4",
         "readabledelta>=0.0.2",
         "apscheduler>=3.6.3",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
         "matrix-nio[e2e]>=0.24.0",
-        "Markdown>=3.1.1",
+        "Markdown>=3.5.2",
         "PyYAML>=5.1.2",
         "dateparser>=0.7.4",
         "readabledelta>=0.0.2",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "dateparser>=1.2.0",
         "readabledelta>=0.0.2",
         "apscheduler>=3.10.4",
-        "pytz>=2020.1",
+        "pytz>=2024.1",
         "arrow>=0.17.0",
         "pretty_cron>=1.2.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "pretty_cron>=1.2.0",
     ],
     extras_require={
-        "postgres": ["psycopg2>=2.8.5"],
+        "postgres": ["psycopg2>=2.9.9"],
         "dev": [
             "isort==5.13.2",
             "flake8==7.0.0",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "matrix-nio[e2e]>=0.24.0",
         "Markdown>=3.5.2",
         "PyYAML>=6.0.1",
-        "dateparser>=0.7.4",
+        "dateparser>=1.2.0",
         "readabledelta>=0.0.2",
         "apscheduler>=3.6.3",
         "pytz>=2020.1",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "PyYAML>=6.0.1",
         "dateparser>=1.2.0",
         "readabledelta>=0.0.2",
-        "apscheduler>=3.6.3",
+        "apscheduler>=3.10.4",
         "pytz>=2020.1",
         "arrow>=0.17.0",
         "pretty_cron>=1.2.0",


### PR DESCRIPTION
The CI has been content for Python 3.12 for a while. This doesn't get us all the way there, but updating might be a good idea after a couple years.

Resolves #148