### PR TITLE
Allow login in with an access token

### DIFF
--- a/matrix_reminder_bot/config.py
+++ b/matrix_reminder_bot/config.py
@@ -126,12 +126,13 @@ class Config:
         self.user_password = self._get_cfg(["matrix", "user_password"], required=False)
         self.access_token = self._get_cfg(["matrix", "access_token"], required=False)
         if self.login_type not in ("password", "token"):
-            raise ConfigError("invalid login_type, must be either `password` or `token`")
+            raise ConfigError(
+                "invalid login_type, must be either `password` or `token`"
+            )
         if self.login_type == "password" and not self.user_password:
             raise ConfigError("login_type set to password but no user_password given")
         if self.login_type == "token" and not self.access_token:
             raise ConfigError("login_type set to token but no access_token given")
-
 
         self.device_id = self._get_cfg(["matrix", "device_id"], required=True)
         self.device_name = self._get_cfg(

--- a/matrix_reminder_bot/main.py
+++ b/matrix_reminder_bot/main.py
@@ -65,21 +65,33 @@ async def main():
     # Keep trying to reconnect on failure (with some time in-between)
     while True:
         try:
-            # Try to login with the configured username/password
+            # Try to login
             try:
-                login_response = await client.login(
-                    password=CONFIG.user_password,
-                    device_name=CONFIG.device_name,
-                )
+                # ... with the configured username/password
+                if CONFIG.login_type == "password":
+                    login_response = await client.login(
+                        password=CONFIG.user_password,
+                        device_name=CONFIG.device_name,
+                    )
 
-                # Check if login failed. Usually incorrect password
-                if type(login_response) is LoginError:
-                    logger.error("Failed to login: %s", login_response.message)
-                    logger.warning("Trying again in 15s...")
+                    # Check if login failed. Usually incorrect password
+                    if type(login_response) is LoginError:
+                        logger.error("Failed to login: %s", login_response.message)
+                        logger.warning("Trying again in 15s...")
 
-                    # Sleep so we don't bombard the server with login requests
-                    sleep(15)
-                    continue
+                        # Sleep so we don't bombard the server with login requests
+                        sleep(15)
+                        continue
+                # ... by using an existing access token
+                elif CONFIG.login_type == "token":
+                    client.restore_login(
+                        user_id=CONFIG.user_id,
+                        device_id=CONFIG.device_id,
+                        access_token=CONFIG.access_token,
+                    )
+                else:
+                    # should be enforced by config.py anyway
+                    assert False, "login_type must be either password or token"
             except LocalProtocolError as e:
                 # There's an edge case here where the user hasn't installed the correct C
                 # dependencies. In that case, a LocalProtocolError is raised on login.

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -9,13 +9,18 @@ command_prefix: "!"
 matrix:
   # The Matrix User ID of the bot account
   user_id: "@bot:example.com"
-  # Matrix account password
+  # Login type (can be `password` or `token`)
+  login_type: token
+  # Matrix account password (if password login)
   user_password: ""
+  # Authenticate directly to Matrix (if token login)
+  access_token: "syt_blablablabla"
   # The public URL at which the homeserver's Client-Server API can be accessed
   homeserver_url: https://example.com
   # The device ID that is a **non pre-existing** device
   # If this device ID already exists, messages will be dropped silently in
   # encrypted rooms
+  # (if using token login type, request the token with this device_id)
   device_id: REMINDER
   # What to name the logged in device
   device_name: Reminder Bot


### PR DESCRIPTION
For instance, in homeservers which only support single-sign-on, logging in with an access token is useful