### PR TITLE
fix cron list formatting for tabs that can't be humanized

### DIFF
--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -464,7 +464,12 @@ class Command(object):
             # Cron-based reminders
             if isinstance(reminder.job.trigger, CronTrigger):
                 # A human-readable cron tab, in addition to the actual tab
-                line += f"{prettify_cron(reminder.cron_tab)} (`{reminder.cron_tab}`); next run {next_execution.humanize()}"
+                human_cron = prettify_cron(reminder.cron_tab)
+                if human_cron != reminder.cron_tab:
+                    line += f"{human_cron} (`{reminder.cron_tab}`)"
+                else:
+                    line += f"`Every {reminder.cron_tab}`"
+                line += f"; next run {next_execution.humanize()}"
 
             # One-time reminders
             elif isinstance(reminder.job.trigger, DateTrigger):


### PR DESCRIPTION
only for tabs that fail to "humanize"

before:
![image](https://github.com/anoadragon453/matrix-reminder-bot/assets/2803622/b3a00395-8bba-4d15-ac89-579442ad0787)
after:
![image](https://github.com/anoadragon453/matrix-reminder-bot/assets/2803622/c605e7c9-0f2e-4c1b-b0fb-6cbab26d5f69)
