### PR TITLE
switch from virtualenv to native venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo pacman -S postgresql-libs
 Create and activate a Python 3 virtual environment:
 
 ```
-virtualenv -p python3 env
+python3 -m venv env
 source env/bin/activate
 ```
 


### PR DESCRIPTION
`venv` is supported natively since Python 3.3, which is well within our requirements already https://docs.python.org/3/library/venv.html and thus favorable to recommend over 3rd party tooling.