### PR TITLE
Add support for canceling reminders by ID

### DIFF
--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -543,19 +543,39 @@ class Command(object):
 
         await send_text_to_room(self.client, self.room.room_id, output)
 
-    @command_syntax("<reminder text>")
+    @command_syntax("<reminder text> | id <reminder id>")
     async def _delete_reminder(self):
-        """Delete a reminder via its reminder text"""
-        reminder_text = " ".join(self.args)
-        if not reminder_text:
-            raise CommandSyntaxError()
+        """Delete a reminder via its reminder text or ID."""
 
-        logger.debug("Known reminders: %s", REMINDERS)
-        logger.debug(
-            "Deleting reminder in room %s: %s", self.room.room_id, reminder_text
-        )
+        if len(self.args) == 2 and self.args[0] == "id":
+            try:
+                id = int(self.args[1]) - 1
+            except ValueError:
+                raise CommandSyntaxError()
 
-        reminder = REMINDERS.get((self.room.room_id, reminder_text.upper()))
+            reminders = get_reminders_by_room_id(self.room.room_id)
+
+            if len(reminders) - 1 < id or id < 0:
+                await send_text_to_room(
+                    self.client,
+                    self.room.room_id,
+                    f"Unknown reminder ID. See `{CONFIG.command_prefix}lr` for available IDs.",
+                )
+                return
+
+            reminder = reminders[id]
+        else:
+            reminder_text = " ".join(self.args)
+            if not reminder_text:
+                raise CommandSyntaxError()
+
+            logger.debug("Known reminders: %s", REMINDERS)
+            logger.debug(
+                "Deleting reminder in room %s: %s", self.room.room_id, reminder_text
+            )
+
+            reminder = REMINDERS.get((self.room.room_id, reminder_text.upper()))
+
         if reminder:
             # Cancel the reminder and associated alarms
             reminder.cancel()
@@ -563,9 +583,9 @@ class Command(object):
             text = "Reminder"
             if reminder.alarm:
                 text = "Alarm"
-            text += f' "*{reminder_text}*" cancelled.'
+            text += f' "*{reminder.reminder_text}*" cancelled.'
         else:
-            text = f"Unknown reminder '{reminder_text}'."
+            text = f"Unknown reminder '{reminder.reminder_text}'."
 
         await send_text_to_room(self.client, self.room.room_id, text)
 
@@ -615,6 +635,7 @@ Cancel a reminder:
 
 ```
 {c}cancelreminder|cancel|cr|c <reminder text>
+{c}cancelreminder|cancel|cr|c id <reminder id>
 ```
 
 **Alarms**

--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -17,7 +17,13 @@ from readabledelta import readabledelta
 from matrix_reminder_bot.config import CONFIG
 from matrix_reminder_bot.errors import CommandError, CommandSyntaxError
 from matrix_reminder_bot.functions import command_syntax, send_text_to_room
-from matrix_reminder_bot.reminder import ALARMS, REMINDERS, SCHEDULER, Reminder
+from matrix_reminder_bot.reminder import (
+    ALARMS,
+    REMINDERS,
+    SCHEDULER,
+    Reminder,
+    get_reminders_by_room_id,
+)
 from matrix_reminder_bot.storage import Storage
 
 logger = logging.getLogger(__name__)
@@ -462,13 +468,10 @@ class Command(object):
             firing_alarms_lines.append(line)
 
         # Sort the reminder types
-        for reminder in REMINDERS.values():
-            # Filter out reminders that don't belong to this room
-            if reminder.room_id != self.room.room_id:
-                continue
+        for id, reminder in enumerate(get_reminders_by_room_id(self.room.room_id)):
 
             # Organise alarms into markdown lists
-            line = "- "
+            line = f"- **[{id + 1}]** "
             if reminder.alarm:
                 # Note that an alarm exists if available
                 alarm_clock_emoji = "⏰"

--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -548,6 +548,7 @@ class Command(object):
         """Delete a reminder via its reminder text or ID."""
 
         if len(self.args) == 2 and self.args[0] == "id":
+            # Delete by reminder ID
             try:
                 id = int(self.args[1]) - 1
             except ValueError:
@@ -565,27 +566,35 @@ class Command(object):
 
             reminder = reminders[id]
         else:
+            # Delete by reminder text
             reminder_text = " ".join(self.args)
             if not reminder_text:
                 raise CommandSyntaxError()
 
-            logger.debug("Known reminders: %s", REMINDERS)
-            logger.debug(
-                "Deleting reminder in room %s: %s", self.room.room_id, reminder_text
-            )
-
             reminder = REMINDERS.get((self.room.room_id, reminder_text.upper()))
 
-        if reminder:
-            # Cancel the reminder and associated alarms
-            reminder.cancel()
+            if not reminder:
+                await send_text_to_room(
+                    self.client,
+                    self.room.room_id,
+                    f"Unknown reminder '{reminder_text}'.",
+                )
+                return
 
-            text = "Reminder"
-            if reminder.alarm:
-                text = "Alarm"
-            text += f' "*{reminder.reminder_text}*" cancelled.'
-        else:
-            text = f"Unknown reminder '{reminder.reminder_text}'."
+        logger.debug("Known reminders: %s", REMINDERS)
+        logger.debug(
+            "Deleting reminder in room %s: %s",
+            self.room.room_id,
+            reminder.reminder_text,
+        )
+
+        # Cancel the reminder and associated alarms
+        reminder.cancel()
+
+        text = "Reminder"
+        if reminder.alarm:
+            text = "Alarm"
+        text += f' "*{reminder.reminder_text}*" cancelled.'
 
         await send_text_to_room(self.client, self.room.room_id, text)
 

--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -281,12 +281,15 @@ class Command(object):
             )
             return
 
+        creation_timestamp_ms = int(datetime.now().timestamp() * 1000)
+
         # Create the reminder
         reminder = Reminder(
             self.client,
             self.store,
             self.room.room_id,
             reminder_text,
+            creation_timestamp_ms,
             start_time=start_time,
             timezone=CONFIG.timezone,
             cron_tab=cron_tab,

--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -339,7 +339,24 @@ class Command(object):
             "d",
             "c",
         ]:
-            await self._delete_reminder()
+            await self._delete_reminder_by_text()
+        elif self.command in [
+            "delreminderid",
+            "deletereminderid",
+            "removereminderid",
+            "cancelreminderid",
+            "delalarmid",
+            "deletealarmid",
+            "removealarmid",
+            "cancelalarmid",
+            "cancelid",
+            "rmid",
+            "crid",
+            "caid",
+            "did",
+            "cid",
+        ]:
+            await self._delete_reminder_by_id()
         elif self.command in ["silence", "s"]:
             await self._silence()
         elif self.command in ["help", "h"]:
@@ -543,43 +560,55 @@ class Command(object):
 
         await send_text_to_room(self.client, self.room.room_id, output)
 
-    @command_syntax("<reminder text> | id <reminder id>")
-    async def _delete_reminder(self):
-        """Delete a reminder via its reminder text or ID."""
+    @command_syntax("<reminder text>")
+    async def _delete_reminder_by_text(self):
+        """Delete a reminder via its reminder text"""
+        reminder_text = " ".join(self.args)
+        if not reminder_text:
+            raise CommandSyntaxError()
 
-        if len(self.args) == 2 and self.args[0] == "id":
-            # Delete by reminder ID
-            try:
-                id = int(self.args[1]) - 1
-            except ValueError:
-                raise CommandSyntaxError()
+        logger.debug("Known reminders: %s", REMINDERS)
+        logger.debug(
+            "Deleting reminder in room %s: %s", self.room.room_id, reminder_text
+        )
 
-            reminders = get_reminders_by_room_id(self.room.room_id)
+        reminder = REMINDERS.get((self.room.room_id, reminder_text.upper()))
+        if reminder:
+            # Cancel the reminder and associated alarms
+            reminder.cancel()
 
-            if len(reminders) - 1 < id or id < 0:
-                await send_text_to_room(
-                    self.client,
-                    self.room.room_id,
-                    f"Unknown reminder ID. See `{CONFIG.command_prefix}lr` for available IDs.",
-                )
-                return
-
-            reminder = reminders[id]
+            text = "Reminder"
+            if reminder.alarm:
+                text = "Alarm"
+            text += f' "*{reminder_text}*" cancelled.'
         else:
-            # Delete by reminder text
-            reminder_text = " ".join(self.args)
-            if not reminder_text:
-                raise CommandSyntaxError()
+            text = f"Unknown reminder '{reminder_text}'."
 
-            reminder = REMINDERS.get((self.room.room_id, reminder_text.upper()))
+        await send_text_to_room(self.client, self.room.room_id, text)
 
-            if not reminder:
-                await send_text_to_room(
-                    self.client,
-                    self.room.room_id,
-                    f"Unknown reminder '{reminder_text}'.",
-                )
-                return
+
+    @command_syntax("<reminder id>")
+    async def _delete_reminder_by_id(self):
+        """Delete a reminder via its ID."""
+        if len(self.args) != 1:
+            raise CommandSyntaxError()
+
+        try:
+            id = int(self.args[0]) - 1
+        except ValueError:
+            raise CommandSyntaxError()
+
+        reminders = get_reminders_by_room_id(self.room.room_id)
+
+        if len(reminders) - 1 < id or id < 0:
+            await send_text_to_room(
+                self.client,
+                self.room.room_id,
+                f"Unknown reminder ID. See `{CONFIG.command_prefix}lr` for available IDs.",
+            )
+            return
+
+        reminder = reminders[id]
 
         logger.debug("Known reminders: %s", REMINDERS)
         logger.debug(
@@ -640,11 +669,16 @@ List all active reminders for a room:
 {c}listreminders|list|lr|l
 ```
 
-Cancel a reminder:
+Cancel a reminder by text:
 
 ```
 {c}cancelreminder|cancel|cr|c <reminder text>
-{c}cancelreminder|cancel|cr|c id <reminder id>
+```
+
+Cancel a reminder by ID (see `!lr`):
+
+```
+{c}cancelreminderid|cancelid|crid|cid <ID>
 ```
 
 **Alarms**

--- a/matrix_reminder_bot/reminder.py
+++ b/matrix_reminder_bot/reminder.py
@@ -197,7 +197,7 @@ class Reminder(object):
         return self.target_user is not None
 
 
-def get_reminders_by_room_id(room_id: str):
+def get_reminders_by_room_id(room_id: str) -> list[Reminder]:
     """Returns all reminders for a given room id, following a consistent sorting order."""
 
     return sorted(

--- a/matrix_reminder_bot/reminder.py
+++ b/matrix_reminder_bot/reminder.py
@@ -46,6 +46,7 @@ class Reminder(object):
         store,
         room_id: str,
         reminder_text: str,
+        creation_timestamp_ms: int,
         start_time: Optional[datetime] = None,
         timezone: Optional[str] = None,
         recurse_timedelta: Optional[timedelta] = None,
@@ -59,6 +60,7 @@ class Reminder(object):
         self.timezone = timezone
         self.start_time = start_time
         self.reminder_text = reminder_text
+        self.creation_timestamp_ms = creation_timestamp_ms
         self.cron_tab = cron_tab
         self.recurse_timedelta = recurse_timedelta
         self.target_user = target_user

--- a/matrix_reminder_bot/reminder.py
+++ b/matrix_reminder_bot/reminder.py
@@ -197,6 +197,15 @@ class Reminder(object):
         return self.target_user is not None
 
 
+def get_reminders_by_room_id(room_id: str):
+    """Returns all reminders for a given room id, following a consistent sorting order."""
+
+    return sorted(
+        filter(lambda x: x.room_id == room_id, REMINDERS.values()),
+        key=lambda x: x.creation_timestamp_ms,
+    )
+
+
 # Global dictionaries
 #
 # Both feature (room_id, reminder_text) tuples as keys

--- a/matrix_reminder_bot/storage.py
+++ b/matrix_reminder_bot/storage.py
@@ -333,7 +333,8 @@ class Storage(object):
                 cron_tab,
                 room_id,
                 target_user,
-                alarm
+                alarm,
+                creation_timestamp_ms
             FROM reminder
         """
         )
@@ -351,6 +352,7 @@ class Storage(object):
             room_id = row[5]
             target_user = row[6]
             alarm = row[7]
+            creation_timestamp_ms = row[8]
 
             if start_time:
                 # If this is a one-off reminder whose start time is in the past, then it will
@@ -384,6 +386,7 @@ class Storage(object):
                 room_id=room_id,
                 target_user=target_user,
                 alarm=alarm,
+                creation_timestamp_ms=creation_timestamp_ms,
             )
 
         return reminders
@@ -412,9 +415,10 @@ class Storage(object):
                 cron_tab,
                 room_id,
                 target_user,
-                alarm
+                alarm,
+                creation_timestamp_ms
             ) VALUES (
-                ?, ?, ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
         """,
             (
@@ -426,6 +430,7 @@ class Storage(object):
                 reminder.room_id,
                 reminder.target_user,
                 reminder.alarm,
+                reminder.creation_timestamp_ms,
             ),
         )
 

--- a/matrix_reminder_bot/storage.py
+++ b/matrix_reminder_bot/storage.py
@@ -9,7 +9,7 @@ from nio import AsyncClient
 from matrix_reminder_bot.config import CONFIG
 from matrix_reminder_bot.reminder import REMINDERS, Reminder
 
-latest_migration_version = 3
+latest_migration_version = 4
 
 logger = logging.getLogger(__name__)
 
@@ -270,6 +270,52 @@ class Storage(object):
             )
 
             logger.info("Database migrated to v3")
+
+        if current_migration_version < 4:
+            logger.info("Migrating the database from v3 to v4...")
+
+            # Add a creation timestamp column to have a proper sorting order for reminders
+            self._execute(
+                """
+                ALTER TABLE reminder
+                    ADD COLUMN creation_timestamp_ms INTEGER
+            """
+            )
+
+            # Use the current unix time as the base timestamp for the first reminder in each room
+            now = int(datetime.now().timestamp() * 1000)
+
+            # Fetch a list of room ids
+            self._execute("SELECT room_id FROM reminder GROUP BY room_id")
+            room_ids = map(lambda x: x[0], self.cursor.fetchall())
+
+            for room_id in room_ids:
+                logger.debug("Migrating room %s", room_id)
+
+                # Fetch reminders for the current room
+                self._execute("SELECT text FROM reminder WHERE room_id = ?", (room_id,))
+                texts = map(lambda x: x[0], self.cursor.fetchall())
+
+                # Iterate over the reminders, setting up the creation timestamps at 1 ms intervals
+                offset_ms = 0
+                for text in texts:
+                    self._execute(
+                        """
+                        UPDATE reminder SET creation_timestamp_ms = ?
+                            WHERE room_id = ?
+                            AND text = ?
+                    """,
+                        (now + offset_ms, room_id, text),
+                    )
+                    offset_ms += 1
+
+            self._execute(
+                """
+                 UPDATE migration_version SET version = 4
+            """
+            )
+
+            logger.info("Database migrated to v4")
 
     def _load_reminders(self) -> Dict[Tuple[str, str], Reminder]:
         """Load reminders from the database

--- a/matrix_reminder_bot/storage.py
+++ b/matrix_reminder_bot/storage.py
@@ -287,14 +287,14 @@ class Storage(object):
 
             # Fetch a list of room ids
             self._execute("SELECT room_id FROM reminder GROUP BY room_id")
-            room_ids = map(lambda x: x[0], self.cursor.fetchall())
+            room_ids = (x[0] for x in self.cursor.fetchall())
 
             for room_id in room_ids:
                 logger.debug("Migrating room %s", room_id)
 
                 # Fetch reminders for the current room
                 self._execute("SELECT text FROM reminder WHERE room_id = ?", (room_id,))
-                texts = map(lambda x: x[0], self.cursor.fetchall())
+                texts = (x[0] for x in self.cursor.fetchall())
 
                 # Iterate over the reminders, setting up the creation timestamps at 1 ms intervals
                 offset_ms = 0


### PR DESCRIPTION
I'm finally working on a fix for #95.

This PR adds support for canceling reminders by a numeric ID. The numeric ID is generated by storing the creation timestamp for each reminder in the database, and then sorting the reminders in the current room by that timestamp. I've opted against introducing a proper primary key because that would break legacy code, and opted against sorting alphabetically by reminder text because that would break the implicit sorting order we had before. Also, I think we can use the creation timestamp in other ways, e.g. for rate limiting. I have explicitly made the sorting order an implementation detail of `get_reminders_by_room_id()`, so the business logic is unaware and we can introduce a primary key later on if we wanted to.

**TODO**
- [x] Fix the bug spotted by @HarHarLinks where `reminder.reminder_text` is accessed even though the reminder is None
- [x] Fix `get_reminders_by_room_id()` missing a return type
- [x] Decide what to do about reminders not addressable by their text
- [x] Add support for canceling reminders by ID
- [ ] Add support for silencing alarms by ID
- [ ] Make the IDs in `!lr` have consistent width so the texts stay aligned
- [ ] Test with Postgres instead of SQLite