### PR TITLE
Add Matrix Reply-Based Reminders With Schema Support

### DIFF
--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -149,9 +149,12 @@ class Command(object):
         logger.debug("Parsing cron command arguments: %s", args_str)
 
         # Split into cron tab and reminder text
-        cron_tab, reminder_text = self._split_command_args(
-            args_str, allow_empty_text=allow_empty_text
-        )
+        try:
+            cron_tab, reminder_text = self._split_command_args(
+                args_str, allow_empty_text=allow_empty_text
+            )
+        except ValueError as exc:
+            raise CommandSyntaxError() from exc
 
         return cron_tab.strip(), reminder_text.strip()
 
@@ -171,9 +174,12 @@ class Command(object):
         args_str = " ".join(self.args)
         logger.debug("Parsing command arguments: %s", args_str)
 
-        time_str, reminder_text = self._split_command_args(
-            args_str, allow_empty_text=allow_empty_text
-        )
+        try:
+            time_str, reminder_text = self._split_command_args(
+                args_str, allow_empty_text=allow_empty_text
+            )
+        except ValueError as exc:
+            raise CommandSyntaxError() from exc
         logger.debug("Got time: %s", time_str)
 
         # Clean up the input
@@ -201,9 +207,12 @@ class Command(object):
             logger.debug("Recurring timedelta: %s", recurse_timedelta)
 
             # Extract the start time
-            time_str, reminder_text = self._split_command_args(
-                reminder_text, allow_empty_text=allow_empty_text
-            )
+            try:
+                time_str, reminder_text = self._split_command_args(
+                    reminder_text, allow_empty_text=allow_empty_text
+                )
+            except ValueError as exc:
+                raise CommandSyntaxError() from exc
             reminder_text = reminder_text.strip()
 
             logger.debug("Start time: %s", time_str)

--- a/matrix_reminder_bot/bot_commands.py
+++ b/matrix_reminder_bot/bot_commands.py
@@ -217,12 +217,13 @@ class Command(object):
         self, args_str: str, allow_empty_text: bool
     ) -> Tuple[str, str]:
         """Split command args into the time/cron segment and reminder text."""
-        try:
-            return args_str.split(";", maxsplit=1)
-        except ValueError:
+        parts = args_str.split(";", maxsplit=1)
+        if len(parts) == 1:
             if allow_empty_text:
                 return args_str, ""
             raise CommandSyntaxError()
+
+        return parts[0], parts[1]
 
     def _allow_missing_reminder_text(self) -> bool:
         """Whether the current command may omit reminder text entirely."""


### PR DESCRIPTION
close #93

- allow reminder commands sent as replies to omit custom text while storing the replied-to event ID so each
    reminder can reference the original message

- add DB migration + persistence for replied_to_event_id, update in-memory keys, and send replies when
    reminders fire

- enhance cancel/silence flows to disambiguate reminders/alarms by reply context and harden syntax parsing so
    missing ; <text> produces a friendly error